### PR TITLE
Simple change + small fixes

### DIFF
--- a/yara_/yara_importer.py
+++ b/yara_/yara_importer.py
@@ -44,7 +44,15 @@ class YaraImporter(object):
                     elif k in ['id', 'rule_id', 'signature_id']:
                         signature_id = v
                     elif k in ['version', 'rule_version', 'revision']:
-                        version = v
+                        if "." in v:
+                            # Maintain version schema (M.m)
+                            version_split = v.split(".", 1)
+                            major = ''.join(filter(str.isdigit, version_split[0]))
+                            minor = ''.join(filter(str.isdigit, version_split[1]))
+                            version = f"{major}.{minor}"
+                        else:
+                            # Fair to assume number found is the major only
+                            version = ''.join(filter(str.isdigit, v))
                     elif k in ['status', 'al_status']:
                         status = v
 

--- a/yara_/yara_updater.py
+++ b/yara_/yara_updater.py
@@ -174,7 +174,7 @@ def git_clone_repo(download_directory: str, source: Dict[str, Any], cur_logger,
 
     git_env = {}
     if ignore_ssl_errors:
-        git_env['GIT_SSL_NO_VERIFY'] = 1
+        git_env['GIT_SSL_NO_VERIFY'] = '1'
 
     if ca_cert:
         add_cacert(ca_cert)


### PR DESCRIPTION
Expecting string-type, not numeric

Second fix relates to revision or version information that contains alphabetic characters such as "v1".
Our current code assumes that version information is just numeric.