### PR TITLE
updated readme to show 4.0.2, service already updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Assemblyline service runs the Yara application against all file types.
 
 #### Execution
 
-Currently AL runs Yara 3.8.1, and therefore supports the following external modules:
+Currently AL runs Yara 4.0.2, and therefore supports the following external modules:
 
 * Dotnet
 * ELF
@@ -29,7 +29,7 @@ Currently AL runs Yara 3.8.1, and therefore supports the following external modu
  
  Rule creation:
  
- * https://yara.readthedocs.io/en/v3.8.1
+ * https://yara.readthedocs.io/en/v4.0.2/
  
  CCCS Standard:
  


### PR DESCRIPTION
service is already running yara 4.0.2 in this commit 
https://github.com/CybercentreCanada/assemblyline-service-yara/commit/0b4a5b024ac89e38d4e45b06cbab14bcd9388a5e#diff-f460046a1c08efa8f8a8f0020288d047a0b11961d9d7bcff8377367bdc9583d7
just needed to update readme.