### PR TITLE
Make updater more resilient

### DIFF
--- a/yara_/yara_updater.py
+++ b/yara_/yara_updater.py
@@ -388,6 +388,7 @@ def yara_update(updater_type, update_config_path, update_output_path,
                     if mode == "w":
                         mode = "a"
                 except:
+                    cur_logger.error(f"Problem parsing {file}")
                     continue
 
             # Check if the file is the same as the last run

--- a/yara_/yara_updater.py
+++ b/yara_/yara_updater.py
@@ -387,8 +387,8 @@ def yara_update(updater_type, update_config_path, update_output_path,
 
                     if mode == "w":
                         mode = "a"
-                except:
-                    cur_logger.error(f"Problem parsing {file}")
+                except Exception as e:
+                    cur_logger.error(f"Problem parsing {file}: {e}")
                     continue
 
             # Check if the file is the same as the last run


### PR DESCRIPTION
Fix for: https://github.com/CybercentreCanada/assemblyline-service-yara/issues/15

Current YARA updater can stop the whole update process if there's a problem parsing on a single signature set.

It should be allowed to move onto the next set and have the problem set logged for inspection.