### PR TITLE
Hotfix for conflicting field types

### DIFF
--- a/yara_/helper.py
+++ b/yara_/helper.py
@@ -13,6 +13,11 @@ Classification = forge.get_classification()
 YARA_EXTERNALS = ["submitter", "mime", "file_type", "tag", "file_name", "file_size"]
 
 
+def externals_to_dict(externals: list[str]) -> dict[str, str | int]:
+    int_fields = ["file_size"]
+    return {f'al_{x.replace(".", "_")}': "" if x not in int_fields else 0 for x in externals}
+
+
 class YaraImporter(object):
     def __init__(self, importer_type: str, al_client: UpdaterClient, logger=None):
         if not logger:

--- a/yara_/update_server.py
+++ b/yara_/update_server.py
@@ -10,7 +10,7 @@ from assemblyline.common import forge
 from assemblyline_v4_service.updater.updater import ServiceUpdater
 from plyara import Plyara, utils
 
-from yara_.helper import YARA_EXTERNALS, YaraImporter, YaraValidator
+from yara_.helper import externals_to_dict, YARA_EXTERNALS, YaraImporter, YaraValidator
 
 classification = forge.get_classification()
 
@@ -81,7 +81,7 @@ def replace_include(include, dirname, processed_files: set[str], cur_logger: log
 class YaraUpdateServer(ServiceUpdater):
     def __init__(self, *args, externals: list[str], **kwargs):
         super().__init__(*args, **kwargs)
-        self.externals = {f'al_{x.replace(".", "_")}': "" for x in externals}
+        self.externals = externals_to_dict(externals)
 
     # A sanity check to make sure we do in fact have things to send to services
     def _inventory_check(self) -> bool:

--- a/yara_/yara_.py
+++ b/yara_/yara_.py
@@ -11,7 +11,7 @@ from assemblyline.odm.models.ontology.results import Signature
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.result import BODY_FORMAT, Heuristic, Result, ResultSection
 
-from yara_.helper import YARA_EXTERNALS, YaraMetadata, YaraValidator
+from yara_.helper import externals_to_dict, YARA_EXTERNALS, YaraMetadata, YaraValidator
 
 
 class Yara(ServiceBase):
@@ -61,7 +61,7 @@ class Yara(ServiceBase):
         self.sha256 = None
 
         # Load externals
-        self.yara_externals = {f'al_{x.replace(".", "_")}': "" for x in externals}
+        self.yara_externals = externals_to_dict(externals)
 
         # Set configuration flags to 4 times the default
         yara.set_config(max_strings_per_rule=40000, stack_size=65536)


### PR DESCRIPTION
The file_size field is the first not-string field. The compilation sets the field's type, but as it used the hardcoded empty string, it later caused the field type conflict when setting the real value.

Apparently, I didn't recreate the service correctly after adding the `file_size` to the list of supported fields :/