### PR TITLE
Skip loading file content (dev)

### DIFF
--- a/yara_/yara_.py
+++ b/yara_/yara_.py
@@ -483,9 +483,9 @@ class Yara(ServiceBase):
                 yara_externals[k] = safe_str(sval)
 
         with self.initialization_lock:
-            data = request.file_contents if self.name == "yara" else ""
+            kwargs = {"filepath": request.file_path} if self.name == "yara" else {"data": ""}
             try:
-                matches = self.rules.match(data=data, externals=yara_externals, allow_duplicate_metadata=True)
+                matches = self.rules.match(externals=yara_externals, allow_duplicate_metadata=True, **kwargs)
                 request.result = self._extract_result_from_matches(matches)
             except Exception as e:
                 # Internal error 30 == exceeded max string matches on rule
@@ -494,7 +494,7 @@ class Yara(ServiceBase):
                 else:
                     try:
                         # Fast mode == Yara skips strings already found
-                        matches = self.rules.match(data=data, externals=yara_externals, fast=True)
+                        matches = self.rules.match(externals=yara_externals, fast=True, **kwargs)
                         result = self._extract_result_from_matches(matches)
                         section = ResultSection("Service Warnings", parent=result)
                         section.add_line(


### PR DESCRIPTION
Loading files to the memory significantly slower down the service. In this way, the file is read directly by YARA.